### PR TITLE
More precise Visual Studio detection

### DIFF
--- a/content/runVisualStudio.ps1
+++ b/content/runVisualStudio.ps1
@@ -30,7 +30,7 @@ if (!(Test-Path "$UserProjectXmlFile")) {
     Invoke-Exe $InstallerFile "/VsVersion=15.0" "/SpecificProductNames=ReSharper" "/Hive=$RootSuffix" "/Silent=True"
 
     $PluginRepository = "$env:LOCALAPPDATA\JetBrains\plugins"
-    $InstallationDirectory = $(Get-ChildItem "$env:APPDATA\JetBrains\ReSharperPlatformVs*\v*_*$RootSuffix\NuGet.Config").Directory
+    $InstallationDirectory = $(Get-ChildItem "$env:APPDATA\JetBrains\ReSharperPlatformVs$VisualStudioMajorVersion\v*_$VisualStudioInstanceId$RootSuffix\NuGet.Config").Directory
 
     # Adapt packages.config
     if (Test-Path "$InstallationDirectory\packages.config") {

--- a/content/settings.ps1
+++ b/content/settings.ps1
@@ -3,7 +3,14 @@ $PluginId = "ReSharperPlugin.SamplePlugin"
 $SolutionPath = "$PSScriptRoot\SamplePlugin.sln"
 $SourceBasePath = "$PSScriptRoot\src\dotnet"
 
-$VisualStudioBaseDirectory = & "$PSScriptRoot\tools\vswhere.exe" "-latest" "-property" "installationPath"
+$VsWhereOutput = [xml] (& "$PSScriptRoot\tools\vswhere.exe" -format xml)
+$VisualStudio = $VsWhereOutput.instances.instance |
+    Where { $_.channelId -match "Release" } |
+    Select-Object -Last 1
+
+$VisualStudioBaseDirectory = $VisualStudio.installationPath
+$VisualStudioMajorVersion = ($VisualStudio.installationVersion -split '\.')[0]
+$VisualStudioInstanceId = $VisualStudio.instanceId
 $DevEnvPath = Get-ChildItem "$VisualStudioBaseDirectory\Common7\IDE\devenv.exe"
 $MSBuildPath = Get-ChildItem "$VisualStudioBaseDirectory\MSBuild\*\Bin\MSBuild.exe"
 


### PR DESCRIPTION
Current version of runVisualStudio download latest stable version of
ReSharper and tries to install it into latest available Visual Studio,
even in Preview. Currently, ReSharper does not play well  with latest
preview of Visual Studio. Also, if user have both Vs15 and Vs16
installed script should prefer stable vs15.