### PR TITLE
Crossplatform build + update everything

### DIFF
--- a/content/.template.config/template.json
+++ b/content/.template.config/template.json
@@ -27,8 +27,8 @@
         "version":{
             "type": "parameter",
             "dataType":"string",
-            "defaultValue": "2019.3",
-            "replaces":"2019.3"
+            "defaultValue": "2019.3.1",
+            "replaces":"2019.3.1"
         }
     },
     "sources": [

--- a/content/build.gradle
+++ b/content/build.gradle
@@ -20,13 +20,14 @@ plugins {
 
 ext {
     isWindows = Os.isFamily(Os.FAMILY_WINDOWS)
-    rdLibDirectory = new File(rootDir, "build/riderRD-${ProductVersion}/lib/rd")
+    rdLibDirectory = {
+        new File(intellij.ideaDependency.classes, "lib/rd")
+    }
 }
 
 repositories {
     maven { url 'https://cache-redirector.jetbrains.com/intellij-repository/snapshots' }
     maven { url 'https://cache-redirector.jetbrains.com/maven-central' }
-    flatDir { dirs rdLibDirectory.absolutePath }
 }
 
 wrapper {
@@ -97,7 +98,9 @@ rdgen {
     def ktOutput = new File(rootDir, "src/rider/main/kotlin/com/jetbrains/rider/plugins/${RiderPluginId.replace('.','/').toLowerCase()}")
 
     verbose = true
-    classpath "${rdLibDirectory}/rider-model.jar"
+    classpath {
+        "${rdLibDirectory()}/rider-model.jar"
+    }
     sources "${modelDir}/rider"
     hashFolder = "${buildDir}"
     packages = "model.rider"

--- a/content/build.gradle
+++ b/content/build.gradle
@@ -7,7 +7,8 @@ buildscript {
     }
 
     dependencies {
-        classpath("com.jetbrains.rd:rd-gen:0.192.2")
+        // https://www.myget.org/feed/rd-snapshots/package/maven/com.jetbrains.rd/rd-gen
+        classpath("com.jetbrains.rd:rd-gen:0.193.146")
     }
 }
 

--- a/content/build.gradle
+++ b/content/build.gradle
@@ -13,8 +13,8 @@ buildscript {
 
 plugins {
     id 'java'
-    id 'org.jetbrains.kotlin.jvm' version '1.3.41'
-    id 'org.jetbrains.intellij' version '0.4.9'
+    id 'org.jetbrains.kotlin.jvm' version '1.3.61'
+    id 'org.jetbrains.intellij' version '0.4.16'
 }
 
 ext {
@@ -29,7 +29,7 @@ repositories {
 }
 
 wrapper {
-    gradleVersion = '4.9'
+    gradleVersion = '6.1.1'
     distributionType = Wrapper.DistributionType.ALL
     distributionUrl = "https://cache-redirector.jetbrains.com/services.gradle.org/distributions/gradle-${gradleVersion}-all.zip"
 }

--- a/content/gradle.properties
+++ b/content/gradle.properties
@@ -9,7 +9,7 @@ PluginVersion=1337.0.0
 BuildConfiguration=Release
 
 # Possible values:
-#    2019.2-SNAPSHOT
-#    2019.2-EAP2-SNAPSHOT
-#    2019.2
-ProductVersion=2019.3
+#    2019.3-SNAPSHOT
+#    2019.3-EAP2-SNAPSHOT
+#    2019.3
+ProductVersion=2019.3.1

--- a/content/gradle/wrapper/gradle-wrapper.properties
+++ b/content/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://cache-redirector.jetbrains.com/services.gradle.org/distributions/gradle-4.9-all.zip
+distributionUrl=https\://cache-redirector.jetbrains.com/services.gradle.org/distributions/gradle-6.1.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/content/protocol/build.gradle
+++ b/content/protocol/build.gradle
@@ -12,6 +12,6 @@ dependencies {
 repositories {
     mavenCentral()
     flatDir {
-        dirs rdLibDirectory.absolutePath
+        dirs rdLibDirectory().absolutePath
     }
 }

--- a/content/src/dotnet/Plugin.props
+++ b/content/src/dotnet/Plugin.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <SdkVersion>2019.3.0</SdkVersion>
+    <SdkVersion>2019.3.1</SdkVersion>
 
     <Title>SamplePlugin</Title>
     <Description>Description</Description>


### PR DESCRIPTION
This PR fixes the `rdLibDirectory` problems on non-Windows OS, and updates the following software:

- Gradle 6.1.1
- Kotlin 1.3.61
- gradle-intellij-plugin 0.4.16
- ReSharper / Rider SDK 2019.3.1