### PR TITLE
Fix runVisualStudio.ps1

### DIFF
--- a/content/runVisualStudio.ps1
+++ b/content/runVisualStudio.ps1
@@ -87,4 +87,4 @@ if (!(Test-Path "$UserProjectXmlFile")) {
 }
 
 Invoke-Exe $MSBuildPath "/t:Restore;Rebuild" "$SolutionPath" "/v:minimal"
-Invoke-Exe $DevEnvPath "/rootSuffix $RootSuffix" "/ReSharper.Internal" "/ReSharper.LogFile ReSharper.log" "/ReSharper.LogLevel Trace"
+Invoke-Exe $DevEnvPath "/rootSuffix $RootSuffix" "/ReSharper.Internal" "/ReSharper.LogFile $PSScriptRoot\ReSharper.log" "/ReSharper.LogLevel Trace"

--- a/content/runVisualStudio.ps1
+++ b/content/runVisualStudio.ps1
@@ -6,6 +6,8 @@ Param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
+Set-Location $PSScriptRoot
+
 . ".\settings.ps1"
 
 $UserProjectXmlFile = "$SourceBasePath\$PluginId\$PluginId.csproj.user"

--- a/content/runVisualStudio.ps1
+++ b/content/runVisualStudio.ps1
@@ -74,7 +74,7 @@ if (!(Test-Path "$UserProjectXmlFile")) {
 
     # Install plugin
     $PluginRepository = "$env:LOCALAPPDATA\JetBrains\plugins"
-    Remove-Item "$PluginRepository\${PluginId}.${Version}" -Recurse
+    Remove-Item "$PluginRepository\${PluginId}.${Version}" -Recurse -ErrorAction Ignore
     Invoke-Exe $MSBuildPath "/t:Restore;Rebuild;Pack" "$SolutionPath" "/v:minimal" "/p:PackageVersion=$Version" "/p:PackageOutputPath=`"$OutputDirectory`""
     Invoke-Exe $NuGetPath install $PluginId -OutputDirectory "$PluginRepository" -Source "$OutputDirectory" -DependencyVersion Ignore
 


### PR DESCRIPTION
### Plugin repository
PluginRepository does not exist at the first build.
Remove-Item throws an error and aborts script.

### Ambiguous execution location
If the script is executed externally, settings.ps1 cannot be imported because the execution path is not constant.

### ReSharper log file
The error occurs because the /ReSharper.LogFile argument is not an absolute path.