### PR TITLE
dotnet build error in build.gradle

### DIFF
--- a/content/build.gradle
+++ b/content/build.gradle
@@ -56,7 +56,7 @@ task compileDotNet {
     doLast {
         exec {
             executable "dotnet"
-            args "msbuild","/t:Restore;Rebuild","${DotnetSolution}","/p:Configuration=${BuildConfiguration}"
+            args "msbuild","/t:Restore;Rebuild","${DotnetSolution}","/p:Configuration=${BuildConfiguration}","/p:HostFullIdentifier="
             workingDir rootDir
         }
     }
@@ -78,7 +78,7 @@ buildPlugin {
 
         exec {
             executable "dotnet"
-            args "msbuild","/t:Pack","${DotnetSolution}","/p:Configuration=${BuildConfiguration}","/p:PackageOutputPath=${rootDir}/output","/p:PackageReleaseNotes=${changeNotes}","/p:PackageVersion=${version}"
+            args "msbuild","/t:Pack","${DotnetSolution}","/p:Configuration=${BuildConfiguration}","/p:HostFullIdentifier=","/p:PackageOutputPath=${rootDir}/output","/p:PackageReleaseNotes=${changeNotes}","/p:PackageVersion=${version}"
         }
     }
 }


### PR DESCRIPTION
When VisualStudio is run, a temporary file of **~.csproj.user** is created and **HostFullIdentifier** is defined.
After run :compileDotNet, :buildPlugin gives exit code 1 error on msbuild.

After debugging this problem an error occurred in the CopyPlugin task of ReSharper.Helper.
And this task is required only in VisualStudio.

To avoid this, I defined **HostFullIdentifier to blank** in msbuild argument.

Finally, we can easily debug, publish Rider and VisualStudio!