### PR TITLE
Fix build plugin when changelog contains `;`

### DIFF
--- a/content/build.gradle
+++ b/content/build.gradle
@@ -70,7 +70,7 @@ buildPlugin {
         def changelogText = file("${rootDir}/CHANGELOG.md").text
         def changelogMatches = changelogText =~ /(?s)(-.+?)(?=##|$)/
         def changeNotes = changelogMatches.collect {
-            it[1].replaceAll(/(?s)- /, "\u2022 ").replaceAll(/`/, "").replaceAll(/,/, "%2C")
+            it[1].replaceAll(/(?s)- /, "\u2022 ").replaceAll(/`/, "").replaceAll(/,/, "%2C").replaceAll(/;/, "%3B")
         }.take(1).join("")
 
         exec {


### PR DESCRIPTION
I got an error while building my plugin because there is `;`  in my changelog

https://github.com/Socolin/NSubstituteComplete/blob/master/CHANGELOG.md (1.3.3)

The error was
```
 MSBUILD : error MSB1006: Property is not valid.
```