### PR TITLE
Update run configurations to support debugging

### DIFF
--- a/content/.idea/.idea.ReSharperPlugin.SamplePlugin/.idea/runConfigurations/Rider__Unix_.xml
+++ b/content/.idea/.idea.ReSharperPlugin.SamplePlugin/.idea/runConfigurations/Rider__Unix_.xml
@@ -1,13 +1,17 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Rider (Unix)" type="ShConfigurationType" singleton="true">
-    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
-    <option name="SCRIPT_PATH" value="$PROJECT_DIR$/gradlew" />
-    <option name="SCRIPT_OPTIONS" value=":runIde" />
-    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
-    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
-    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
-    <option name="INTERPRETER_PATH" value="/bin/bash" />
-    <option name="INTERPRETER_OPTIONS" value="" />
-    <method v="2" />
+  <configuration default="false" name="Rider (Unix)" type="RunNativeExe" factoryName="Native Executable" singleton="true">
+    <envs>
+      <env name="RUNNING_FROM_RIDER" value="1" />
+      <env name="RESHARPER_HOST_DEBUG_SELF" value="1" />
+    </envs>
+    <option name="EXE_PATH" value="$PROJECT_DIR$/gradlew" />
+    <option name="PROGRAM_PARAMETERS" value="runIde" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="PASS_PARENT_ENVS" value="1" />
+    <option name="USE_MONO" value="0" />
+    <option name="RUNTIME_ARGUMENTS" value="" />
+    <method v="2">
+      <option name="Build Solution" enabled="true" />
+    </method>
   </configuration>
 </component>

--- a/content/.idea/.idea.ReSharperPlugin.SamplePlugin/.idea/runConfigurations/Rider__Windows_.xml
+++ b/content/.idea/.idea.ReSharperPlugin.SamplePlugin/.idea/runConfigurations/Rider__Windows_.xml
@@ -1,11 +1,17 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Rider (Windows)" type="RunNativeExe" factoryName="Native Executable">
+    <envs>
+      <env name="RUNNING_FROM_RIDER" value="1" />
+      <env name="RESHARPER_HOST_DEBUG_SELF" value="1" />
+    </envs>
     <option name="EXE_PATH" value="C:\Windows\System32\cmd.exe" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
     <option name="PROGRAM_PARAMETERS" value="/c gradlew.bat :runIde" />
     <option name="PASS_PARENT_ENVS" value="1" />
     <option name="USE_EXTERNAL_CONSOLE" value="0" />
     <module name="" />
-    <method v="2" />
+    <method v="2">
+      <option name="Build Solution" enabled="true" />
+    </method>
   </configuration>
 </component>

--- a/content/.idea/.idea.ReSharperPlugin.SamplePlugin/.idea/runConfigurations/rdgen__Unix_.xml
+++ b/content/.idea/.idea.ReSharperPlugin.SamplePlugin/.idea/runConfigurations/rdgen__Unix_.xml
@@ -1,13 +1,10 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Generate protocol (Unix)" type="ShConfigurationType" singleton="true">
-    <option name="INDEPENDENT_SCRIPT_PATH" value="true" />
-    <option name="SCRIPT_PATH" value="$PROJECT_DIR$/gradlew" />
-    <option name="SCRIPT_OPTIONS" value=":rdgen" />
-    <option name="INDEPENDENT_SCRIPT_WORKING_DIRECTORY" value="true" />
-    <option name="SCRIPT_WORKING_DIRECTORY" value="$PROJECT_DIR$" />
-    <option name="INDEPENDENT_INTERPRETER_PATH" value="true" />
-    <option name="INTERPRETER_PATH" value="/bin/bash" />
-    <option name="INTERPRETER_OPTIONS" value="" />
-    <method v="2" />
+  <configuration default="false" name="Rider (Unix)" type="RunNativeExe" factoryName="Native Executable" singleton="true">
+    <option name="EXE_PATH" value="$PROJECT_DIR$/gradlew" />
+    <option name="PROGRAM_PARAMETERS" value="rdgen" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="PASS_PARENT_ENVS" value="1" />
+    <option name="USE_MONO" value="0" />
+    <option name="RUNTIME_ARGUMENTS" value="" />
   </configuration>
 </component>


### PR DESCRIPTION
New run configurations will launch the frontend, which then launches the backend under the debugger, allowing debugging of ShellComponents. It should also disable runtime optimisations to make stepping into 3rd party code easier. Only works in Rider 2021.1, when targetting 211 and above.