### PR TITLE
Include `.idea` folder items inside `.gitignore` at any folder level

### DIFF
--- a/template/content/.gitignore
+++ b/template/content/.gitignore
@@ -13,10 +13,10 @@ output
 *.cache
 
 # IDEs
-/.idea/*.iml
-/.idea/*.xml
-/.idea/.idea.*/*.iml
-/.idea/.idea.*/.idea/*.xml
+/**/.idea/*.iml
+/**/.idea/*.xml
+/**/.idea/.idea.*/*.iml
+/**/.idea/.idea.*/.idea/*.xml
 .vs
 _ReSharper*
 _dotTrace*


### PR DESCRIPTION
Currently, `gitignore` only affects root `.idea` folder.

.NET solution located inside `src/dotnet` folder, when opening in Rider also produce `.idea` which includes local workspace related files that should be ignored the same way as in root Gradle project.

The proposed change is generic and will also impact any repository structure with any number of .NET/Java project.