### PR TITLE
The new way to specify dependencies

### DIFF
--- a/samples/Actions/src/dotnet/ReSharperPlugin.Actions/ReSharperPlugin.Actions.csproj
+++ b/samples/Actions/src/dotnet/ReSharperPlugin.Actions/ReSharperPlugin.Actions.csproj
@@ -15,7 +15,6 @@
 
   <ItemGroup>
     <PackageReference Include="JetBrains.ReSharper.SDK" Version="$(SdkVersion)" PrivateAssets="all" />
-    <!-- TODO: https://github.com/NuGet/Home/issues/7154 -->
     <PackageReference Include="Wave" Version="$(WaveVersion)" />
   </ItemGroup>
 

--- a/samples/Actions/src/dotnet/ReSharperPlugin.Actions/ReSharperPlugin.Actions.csproj
+++ b/samples/Actions/src/dotnet/ReSharperPlugin.Actions/ReSharperPlugin.Actions.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="JetBrains.ReSharper.SDK" Version="$(SdkVersion)" PrivateAssets="all" />
     <!-- TODO: https://github.com/NuGet/Home/issues/7154 -->
-    <PackageReference Include="Wave" Version="[$(WaveVersion),$(UpperWaveVersion))" />
+    <PackageReference Include="Wave" Version="$(WaveVersion)" />
   </ItemGroup>
 
 

--- a/samples/CefToolWindow/src/dotnet/ReSharperPlugin.CefToolWindow/ReSharperPlugin.CefToolWindow.csproj
+++ b/samples/CefToolWindow/src/dotnet/ReSharperPlugin.CefToolWindow/ReSharperPlugin.CefToolWindow.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="CefSharp.Wpf" Version="105.3.390" PrivateAssets="all" />
     <PackageReference Include="JetBrains.ReSharper.SDK" Version="$(SdkVersion)" PrivateAssets="all" />
     <!-- TODO: https://github.com/NuGet/Home/issues/7154 -->
-    <PackageReference Include="Wave" Version="[$(WaveVersion),$(UpperWaveVersion))" />
+    <PackageReference Include="Wave" Version="$(WaveVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/CodeInspections/src/dotnet/ReSharperPlugin.CodeInspections/ReSharperPlugin.CodeInspections.csproj
+++ b/samples/CodeInspections/src/dotnet/ReSharperPlugin.CodeInspections/ReSharperPlugin.CodeInspections.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="JetBrains.ReSharper.SDK" Version="$(SdkVersion)" PrivateAssets="all" />
     <!-- TODO: https://github.com/NuGet/Home/issues/7154 -->
-    <PackageReference Include="Wave" Version="[$(WaveVersion),$(UpperWaveVersion))" />
+    <PackageReference Include="Wave" Version="$(WaveVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/CodeVision/src/dotnet/ReSharperPlugin.CodeVision/ReSharperPlugin.CodeVision.csproj
+++ b/samples/CodeVision/src/dotnet/ReSharperPlugin.CodeVision/ReSharperPlugin.CodeVision.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="JetBrains.ReSharper.SDK" Version="$(SdkVersion)" PrivateAssets="all" />
     <!-- TODO: https://github.com/NuGet/Home/issues/7154 -->
-    <PackageReference Include="Wave" Version="[$(WaveVersion),$(UpperWaveVersion))" />
+    <PackageReference Include="Wave" Version="$(WaveVersion)" />
   </ItemGroup>
 
 

--- a/samples/DataContext/src/dotnet/Directory.Build.props
+++ b/samples/DataContext/src/dotnet/Directory.Build.props
@@ -21,7 +21,6 @@
   <PropertyGroup>
     <WaveVersionBase>$(SdkVersion.Substring(2,2))$(SdkVersion.Substring(5,1))</WaveVersionBase>
     <WaveVersion>$(WaveVersionBase).0.0$(SdkVersion.Substring(8))</WaveVersion>
-    <UpperWaveVersion>$(WaveVersionBase).9999.0</UpperWaveVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/DataContext/src/dotnet/Directory.Build.props
+++ b/samples/DataContext/src/dotnet/Directory.Build.props
@@ -19,8 +19,7 @@
   <Import Project="Plugin.props" />
 
   <PropertyGroup>
-    <WaveVersionBase>$(SdkVersion.Substring(2,2))$(SdkVersion.Substring(5,1))</WaveVersionBase>
-    <WaveVersion>$(WaveVersionBase).0.0$(SdkVersion.Substring(8))</WaveVersion>
+    <WaveVersion>$(SdkVersion.Substring(2,2))$(SdkVersion.Substring(5,1)).0.0</WaveVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/DataContext/src/dotnet/ReSharperPlugin.DataContext/ReSharperPlugin.DataContext.csproj
+++ b/samples/DataContext/src/dotnet/ReSharperPlugin.DataContext/ReSharperPlugin.DataContext.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="JetBrains.ReSharper.SDK" Version="$(SdkVersion)" PrivateAssets="all" />
     <!-- TODO: https://github.com/NuGet/Home/issues/7154 -->
-    <PackageReference Include="Wave" Version="[$(WaveVersion),$(UpperWaveVersion))" />
+    <PackageReference Include="Wave" Version="$(WaveVersion)" />
   </ItemGroup>
 
 

--- a/samples/InlayHints/src/dotnet/ReSharperPlugin.InlayHints/ReSharperPlugin.InlayHints.csproj
+++ b/samples/InlayHints/src/dotnet/ReSharperPlugin.InlayHints/ReSharperPlugin.InlayHints.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="JetBrains.ReSharper.SDK" Version="$(SdkVersion)" PrivateAssets="all" />
     <!-- TODO: https://github.com/NuGet/Home/issues/7154 -->
-    <PackageReference Include="Wave" Version="[$(WaveVersion),$(UpperWaveVersion))" />
+    <PackageReference Include="Wave" Version="$(WaveVersion)" />
   </ItemGroup>
 
 

--- a/samples/Miscellaneous/src/dotnet/Directory.Build.props
+++ b/samples/Miscellaneous/src/dotnet/Directory.Build.props
@@ -21,7 +21,6 @@
   <PropertyGroup>
     <WaveVersionBase>$(SdkVersion.Substring(2,2))$(SdkVersion.Substring(5,1))</WaveVersionBase>
     <WaveVersion>$(WaveVersionBase).0.0$(SdkVersion.Substring(8))</WaveVersion>
-    <UpperWaveVersion>$(WaveVersionBase).9999.0</UpperWaveVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Miscellaneous/src/dotnet/Directory.Build.props
+++ b/samples/Miscellaneous/src/dotnet/Directory.Build.props
@@ -19,8 +19,7 @@
   <Import Project="Plugin.props" />
 
   <PropertyGroup>
-    <WaveVersionBase>$(SdkVersion.Substring(2,2))$(SdkVersion.Substring(5,1))</WaveVersionBase>
-    <WaveVersion>$(WaveVersionBase).0.0$(SdkVersion.Substring(8))</WaveVersion>
+    <WaveVersion>$(SdkVersion.Substring(2,2))$(SdkVersion.Substring(5,1)).0.0</WaveVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Miscellaneous/src/dotnet/ReSharperPlugin.Miscellaneous/ReSharperPlugin.Miscellaneous.csproj
+++ b/samples/Miscellaneous/src/dotnet/ReSharperPlugin.Miscellaneous/ReSharperPlugin.Miscellaneous.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="JetBrains.ReSharper.SDK" Version="$(SdkVersion)" PrivateAssets="all" />
     <!-- TODO: https://github.com/NuGet/Home/issues/7154 -->
-    <PackageReference Include="Wave" Version="[$(WaveVersion),$(UpperWaveVersion))" />
+    <PackageReference Include="Wave" Version="$(WaveVersion)" />
   </ItemGroup>
 
 

--- a/samples/Notifications/src/dotnet/ReSharperPlugin.Notifications/ReSharperPlugin.Notifications.csproj
+++ b/samples/Notifications/src/dotnet/ReSharperPlugin.Notifications/ReSharperPlugin.Notifications.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="JetBrains.ReSharper.SDK" Version="$(SdkVersion)" PrivateAssets="all" />
     <!-- TODO: https://github.com/NuGet/Home/issues/7154 -->
-    <PackageReference Include="Wave" Version="[$(WaveVersion),$(UpperWaveVersion))" />
+    <PackageReference Include="Wave" Version="$(WaveVersion)" />
   </ItemGroup>
 
 

--- a/samples/OptionPages/src/dotnet/ReSharperPlugin.OptionPages/ReSharperPlugin.OptionPages.csproj
+++ b/samples/OptionPages/src/dotnet/ReSharperPlugin.OptionPages/ReSharperPlugin.OptionPages.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="JetBrains.ReSharper.SDK" Version="$(SdkVersion)" PrivateAssets="all" />
     <!-- TODO: https://github.com/NuGet/Home/issues/7154 -->
-    <PackageReference Include="Wave" Version="[$(WaveVersion),$(UpperWaveVersion))" />
+    <PackageReference Include="Wave" Version="$(WaveVersion)" />
   </ItemGroup>
 
 

--- a/samples/PostfixTemplates/src/dotnet/ReSharperPlugin.PostfixTemplates/ReSharperPlugin.PostfixTemplates.csproj
+++ b/samples/PostfixTemplates/src/dotnet/ReSharperPlugin.PostfixTemplates/ReSharperPlugin.PostfixTemplates.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="JetBrains.ReSharper.SDK" Version="$(SdkVersion)" PrivateAssets="all" />
     <!-- TODO: https://github.com/NuGet/Home/issues/7154 -->
-    <PackageReference Include="Wave" Version="[$(WaveVersion),$(UpperWaveVersion))" />
+    <PackageReference Include="Wave" Version="$(WaveVersion)" />
   </ItemGroup>
 
 

--- a/samples/QuickDocProvider/src/dotnet/Directory.Build.props
+++ b/samples/QuickDocProvider/src/dotnet/Directory.Build.props
@@ -21,7 +21,6 @@
   <PropertyGroup>
     <WaveVersionBase>$(SdkVersion.Substring(2,2))$(SdkVersion.Substring(5,1))</WaveVersionBase>
     <WaveVersion>$(WaveVersionBase).0.0$(SdkVersion.Substring(8))</WaveVersion>
-    <UpperWaveVersion>$(WaveVersionBase).9999.0</UpperWaveVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/QuickDocProvider/src/dotnet/Directory.Build.props
+++ b/samples/QuickDocProvider/src/dotnet/Directory.Build.props
@@ -19,8 +19,7 @@
   <Import Project="Plugin.props" />
 
   <PropertyGroup>
-    <WaveVersionBase>$(SdkVersion.Substring(2,2))$(SdkVersion.Substring(5,1))</WaveVersionBase>
-    <WaveVersion>$(WaveVersionBase).0.0$(SdkVersion.Substring(8))</WaveVersion>
+    <WaveVersion>$(SdkVersion.Substring(2,2))$(SdkVersion.Substring(5,1)).0.0</WaveVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/QuickDocProvider/src/dotnet/ReSharperPlugin.QuickDocProvider/ReSharperPlugin.QuickDocProvider.csproj
+++ b/samples/QuickDocProvider/src/dotnet/ReSharperPlugin.QuickDocProvider/ReSharperPlugin.QuickDocProvider.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="JetBrains.ReSharper.SDK" Version="$(SdkVersion)" PrivateAssets="all" />
     <!-- TODO: https://github.com/NuGet/Home/issues/7154 -->
-    <PackageReference Include="Wave" Version="[$(WaveVersion),$(UpperWaveVersion))" />
+    <PackageReference Include="Wave" Version="$(WaveVersion)" />
   </ItemGroup>
 
 

--- a/samples/RdProtocol/src/dotnet/ReSharperPlugin.RdProtocol/ReSharperPlugin.RdProtocol.csproj
+++ b/samples/RdProtocol/src/dotnet/ReSharperPlugin.RdProtocol/ReSharperPlugin.RdProtocol.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="JetBrains.ReSharper.SDK" Version="$(SdkVersion)" PrivateAssets="all" />
     <!-- TODO: https://github.com/NuGet/Home/issues/7154 -->
-    <PackageReference Include="Wave" Version="[$(WaveVersion),$(UpperWaveVersion))" />
+    <PackageReference Include="Wave" Version="$(WaveVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/SettingsProvider/src/dotnet/ReSharperPlugin.SettingsProvider/ReSharperPlugin.SettingsProvider.csproj
+++ b/samples/SettingsProvider/src/dotnet/ReSharperPlugin.SettingsProvider/ReSharperPlugin.SettingsProvider.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="JetBrains.ReSharper.SDK" Version="$(SdkVersion)" PrivateAssets="all" />
     <!-- TODO: https://github.com/NuGet/Home/issues/7154 -->
-    <PackageReference Include="Wave" Version="[$(WaveVersion),$(UpperWaveVersion))" />
+    <PackageReference Include="Wave" Version="$(WaveVersion)" />
   </ItemGroup>
 
 

--- a/template/content/src/dotnet/ReSharperPlugin.SamplePlugin/ReSharperPlugin.SamplePlugin.csproj
+++ b/template/content/src/dotnet/ReSharperPlugin.SamplePlugin/ReSharperPlugin.SamplePlugin.csproj
@@ -15,7 +15,6 @@
 
   <ItemGroup>
     <PackageReference Include="JetBrains.ReSharper.SDK" Version="$(SdkVersion)" PrivateAssets="all" />
-    <!-- TODO: https://github.com/NuGet/Home/issues/7154 -->
     <PackageReference Include="Wave" Version="$(WaveVersion)" />
   </ItemGroup>
 

--- a/template/content/src/dotnet/ReSharperPlugin.SamplePlugin/ReSharperPlugin.SamplePlugin.csproj
+++ b/template/content/src/dotnet/ReSharperPlugin.SamplePlugin/ReSharperPlugin.SamplePlugin.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="JetBrains.ReSharper.SDK" Version="$(SdkVersion)" PrivateAssets="all" />
     <!-- TODO: https://github.com/NuGet/Home/issues/7154 -->
-    <PackageReference Include="Wave" Version="[$(WaveVersion),$(UpperWaveVersion))" />
+    <PackageReference Include="Wave" Version="$(WaveVersion)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
With the introduction of API verifier it is now recommended to specify dependency on wave without using interval notation. The actual compatibility can be inferred by the verification stage during installation or on Marketplace with the help of API verifier.