### PR TITLE
Keep InlayHints sample alive

### DIFF
--- a/samples/InlayHints/src/dotnet/ReSharperPlugin.InlayHints/SampleAdornmentDataModel.cs
+++ b/samples/InlayHints/src/dotnet/ReSharperPlugin.InlayHints/SampleAdornmentDataModel.cs
@@ -1,26 +1,33 @@
 using System.Collections.Generic;
-using JetBrains.Application.InlayHints;
 using JetBrains.Application.UI.Controls.BulbMenu.Items;
 using JetBrains.Application.UI.Controls.Utils;
 using JetBrains.Application.UI.PopupLayout;
-using JetBrains.TextControl.DocumentMarkup;
+using JetBrains.TextControl.DocumentMarkup.IntraTextAdornments;
 using JetBrains.UI.Icons;
 using JetBrains.UI.RichText;
 using JetBrains.Util;
 
-namespace ReSharperPlugin.CodeVision;
+namespace ReSharperPlugin.InlayHints;
 
 public class SampleAdornmentDataModel : IIntraTextAdornmentDataModel
 {
     public SampleAdornmentDataModel(string parameterName)
     {
         Text = parameterName + ":";
+        Data = new IntraTextAdornmentData(Text, IconId,
+            (IsNavigable ? IntraTextAdornmentFlags.IsNavigable : 0)
+          | (HasContextMenu ? IntraTextAdornmentFlags.HasContextMenu : 0)
+          | (SelectionRange is not null ? IntraTextAdornmentFlags.HasSelectionRange : 0)
+          | IntraTextAdornmentFlags.IsNavigable,
+            new IntraTextPlacement(Order), InlayHintsMode);
     }
 
     public void ExecuteNavigation(PopupWindowContextSource popupWindowContextSource)
     {
         MessageBox.ShowInfo($"{nameof(SampleAdornmentDataModel)}.{nameof(ExecuteNavigation)}", "ReSharper SDK");
     }
+
+    public IntraTextAdornmentData Data { get; }
 
     public RichText Text { get; }
     public bool HasContextMenu { get; }

--- a/samples/InlayHints/src/dotnet/ReSharperPlugin.InlayHints/SampleAdornmentProvider.cs
+++ b/samples/InlayHints/src/dotnet/ReSharperPlugin.InlayHints/SampleAdornmentProvider.cs
@@ -1,7 +1,8 @@
 using JetBrains.ProjectModel;
 using JetBrains.TextControl.DocumentMarkup;
+using JetBrains.TextControl.DocumentMarkup.IntraTextAdornments;
 
-namespace ReSharperPlugin.CodeVision;
+namespace ReSharperPlugin.InlayHints;
 
 [SolutionComponent]
 public class SampleAdornmentProvider : IHighlighterIntraTextAdornmentProvider

--- a/samples/InlayHints/src/dotnet/ReSharperPlugin.InlayHints/SampleHintElementAnalyzer.cs
+++ b/samples/InlayHints/src/dotnet/ReSharperPlugin.InlayHints/SampleHintElementAnalyzer.cs
@@ -3,10 +3,9 @@ using JetBrains.Metadata.Reader.Impl;
 using JetBrains.ReSharper.Feature.Services.Daemon;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.CSharp.Tree;
-using JetBrains.ReSharper.Psi.Impl;
 using JetBrains.ReSharper.Psi.Tree;
 
-namespace ReSharperPlugin.CodeVision;
+namespace ReSharperPlugin.InlayHints;
 
 [ElementProblemAnalyzer(
     typeof(IAttribute),

--- a/samples/InlayHints/src/dotnet/ReSharperPlugin.InlayHints/SampleInlayHint.cs
+++ b/samples/InlayHints/src/dotnet/ReSharperPlugin.InlayHints/SampleInlayHint.cs
@@ -4,8 +4,9 @@ using JetBrains.ReSharper.Feature.Services.Daemon;
 using JetBrains.ReSharper.Feature.Services.InlayHints;
 using JetBrains.ReSharper.Psi.Tree;
 using JetBrains.TextControl.DocumentMarkup;
+using JetBrains.TextControl.DocumentMarkup.VisualStudio;
 
-namespace ReSharperPlugin.CodeVision;
+namespace ReSharperPlugin.InlayHints;
 
 [RegisterHighlighterGroup(
     HighlightAttributeGroupId,
@@ -20,6 +21,8 @@ namespace ReSharperPlugin.CodeVision;
     DarkBackgroundColor = "#3B3B3C",
     EffectType = EffectType.INTRA_TEXT_ADORNMENT,
     Layer = HighlighterLayer.ADDITIONAL_SYNTAX,
+    VsGenerateClassificationDefinition = VsGenerateDefinition.VisibleClassification,
+    VsBaseClassificationType = VsPredefinedClassificationType.Text,
     TransmitUpdates = true)]
 [DaemonIntraTextAdornmentProvider(typeof(SampleAdornmentProvider))]
 [DaemonTooltipProvider(typeof(InlayHintTooltipProvider))]

--- a/samples/InlayHints/src/dotnet/ReSharperPlugin.InlayHints/SampleInlayHintBase.cs
+++ b/samples/InlayHints/src/dotnet/ReSharperPlugin.InlayHints/SampleInlayHintBase.cs
@@ -1,10 +1,9 @@
-using JetBrains.Application.UI.Tooltips;
 using JetBrains.DocumentModel;
 using JetBrains.ReSharper.Feature.Services.InlayHints;
 using JetBrains.ReSharper.Psi.Tree;
 using JetBrains.UI.RichText;
 
-namespace ReSharperPlugin.CodeVision;
+namespace ReSharperPlugin.InlayHints;
 
 public abstract class SampleInlayHintBase : IInlayHintWithDescriptionHighlighting
 {


### PR DESCRIPTION
There are 2 problems with InlayHints sample:
1. Outdated namespaces.
2. Sample doesn't work with Visual Studio cause of not filled Data in DataModel and not passed VsBaseClassificationType argument for RegisterHighlighterAttribute.